### PR TITLE
Bugfix: A paused stream will continue, when new item is triggered to …

### DIFF
--- a/objects/monitor.py
+++ b/objects/monitor.py
@@ -195,7 +195,7 @@ class Monitor(monitor.Monitor):
             window('emby.playlist.start', clear=True)
 
     def Playlist_OnClear(self, server, data, *args, **kwargs):
-
+        xbmc.Player().stop()
         self.player.played = {}
 
         if data['playlistid']:


### PR DESCRIPTION
…be played. The paused stream continues until new item is fully loaded.